### PR TITLE
Update Demo.md to resolve Redis Cache demo issues

### DIFF
--- a/Presentation/Web/Demo.md
+++ b/Presentation/Web/Demo.md
@@ -31,7 +31,9 @@ This demo shows using Redis Cache to make
 
 ### Prerequisites
 
-1. Add Redis Cache Server connection details to:
+1. Create 2 Redis cache services on Azure
+1. Ensure redis cache services have enabled "NON-SSL PORT" - 6379 . This feature is disabled by default.
+1. Add each Redis Cache Server connection details to:
 
 	* CustomerQuery web.config
 	* CacheFill app.config


### PR DESCRIPTION
Update Demo.md to resolve Redis Cache demo issues.

##Cache Accounts
This Demo uses 2 different cache services. Before it starts populating cache for customer or for products the code calls  
```` 
connection.Server.FlushDb(0);
````
So if both redis services are the same, the 2nd will the delete the 1st loaded cache data.

##Non SSL port support

This Demo requires "NON-SSL PORT" to be enabled on azure redis cache services to work
 poroperly. If it doesn't the Demo will crash.

This featuire is disabled by default after creating redis cache service.